### PR TITLE
Fix missing pointer dereference

### DIFF
--- a/src/pvxs/data.h
+++ b/src/pvxs/data.h
@@ -406,7 +406,7 @@ public:
     TypeDef& operator+=(const Iterable& children) {
         auto edit = _append_start();
         for(auto& child : children) {
-            _append(edit, child);
+            _append(*edit, child);
         }
         _append_finish(std::move(edit));
         return *this;


### PR DESCRIPTION
Some tests should be also added for 
```cpp
template<typename Iterable>
    TypeDef& operator+=(const Iterable& children) 
```